### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ clj-multicodec
 [![Build Status](https://travis-ci.org/greglook/clj-multicodec.svg?branch=develop)](https://travis-ci.org/greglook/clj-multicodec)
 [![Coverage Status](https://coveralls.io/repos/greglook/clj-multicodec/badge.svg?branch=develop&service=github)](https://coveralls.io/github/greglook/clj-multicodec?branch=develop)
 [![API codox](https://img.shields.io/badge/doc-API-blue.svg)](https://greglook.github.io/clj-multicodec/api/)
-[![marginalia docs](http://img.shields.io/badge/doc-marginalia-blue.svg)](https://greglook.github.io/clj-multicodec/marginalia/uberdoc.html)
+[![marginalia docs](https://img.shields.io/badge/doc-marginalia-blue.svg)](https://greglook.github.io/clj-multicodec/marginalia/uberdoc.html)
 [![Join the chat at https://gitter.im/greglook/clj-multicodec](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/greglook/clj-multicodec)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
 
@@ -28,7 +28,7 @@ both human and machine-readable.
 Library releases are published on Clojars. To use the latest version with
 Leiningen, add the following dependency to your project definition:
 
-[![Clojars Project](http://clojars.org/mvxcvi/multicodec/latest-version.svg)](http://clojars.org/mvxcvi/multicodec)
+[![Clojars Project](https://clojars.org/mvxcvi/multicodec/latest-version.svg)](http://clojars.org/mvxcvi/multicodec)
 
 ## Usage
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://clojars.org/mvxcvi/multicodec | https://clojars.org/mvxcvi/multicodec 
http://clojars.org/mvxcvi/multicodec/latest-version.svg | https://clojars.org/mvxcvi/multicodec/latest-version.svg 
http://img.shields.io/badge/doc-marginalia-blue.svg | https://img.shields.io/badge/doc-marginalia-blue.svg 
